### PR TITLE
disable tiered compilation for benchmark runs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,5 +8,6 @@
                  [com.cognitect/transit-clj "0.8.259"]
                  [criterium "0.4.3"]
                  [org.clojure/clojure "1.6.0"]]
+  :jvm-opts ^:replace ["-Xms1g" "-Xmx1g" "-server" "-XX:+AggressiveOpts" "-XX:+UseFastAccessorMethods"]
   :main transit-bench.bench
   :aot [transit-bench.bench])


### PR DESCRIPTION
by default, leiningen sets the JVM up for startup time, via tiered
compilation (see https://github.com/technomancy/leiningen/wiki/Faster).

This doesn't play so well with benchmarks, so when running benchmarks,
you need to turn off tiered compilation. Also nearly every production
jvm runs with AggressiveOpts, UseFastAccessorMethods, and -server, so
enable them too.

benchmark runs here:
(note: run on a laptop, so not really indicitive of production results)
https://gist.github.com/tcrayford/fa86fbeb32c6a95758e1

There is a 2x performance difference on some of the benchmarks between
the runs though, which is pretty significant
